### PR TITLE
Improve performance with new graph struct and priority queue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VertexEliminationOrders"
 uuid = "8b81cbe5-9619-4878-8f6a-289d09070662"
 authors = ["John Brennan <johnmarkbrennan@gmail.com> and contributors"]
-version = "0.2.0"
+version = "1.0.0"
 
 [deps]
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "VertexEliminationOrders"
 uuid = "8b81cbe5-9619-4878-8f6a-289d09070662"
-authors = ["John Brennan <john.brennan@ichec.ie> and contributors"]
+authors = ["John Brennan <johnmarkbrennan@gmail.com> and contributors"]
 version = "0.2.0"
 
 [deps]
@@ -8,7 +8,7 @@ LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,11 @@
 name = "VertexEliminationOrders"
 uuid = "8b81cbe5-9619-4878-8f6a-289d09070662"
 authors = ["John Brennan <john.brennan@ichec.ie> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["John Brennan <john.brennan@ichec.ie> and contributors"]
 version = "0.1.0"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["John Brennan <john.brennan@ichec.ie> and contributors"]
 version = "0.1.0"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/src/VertexEliminationOrders.jl
+++ b/src/VertexEliminationOrders.jl
@@ -2,12 +2,14 @@ module VertexEliminationOrders
 
 using Base.Threads
 using Random
-using Reexport
-@reexport using LightGraphs
+# using Reexport
+# @reexport using LightGraphs
+import LightGraphs as lg
 
 include("utils.jl")
-include("treewidth_heuristics.jl")
-include("dfs_utils.jl")
-include("dfs.jl")
+include("graph.jl")
+# include("treewidth_heuristics.jl")
+# include("dfs_utils.jl")
+# include("dfs.jl")
 
 end

--- a/src/VertexEliminationOrders.jl
+++ b/src/VertexEliminationOrders.jl
@@ -8,8 +8,8 @@ import LightGraphs as lg
 
 include("utils.jl")
 include("graph.jl")
-# include("treewidth_heuristics.jl")
-# include("dfs_utils.jl")
-# include("dfs.jl")
+include("treewidth_heuristics.jl")
+include("dfs_utils.jl")
+include("dfs.jl")
 
 end

--- a/src/VertexEliminationOrders.jl
+++ b/src/VertexEliminationOrders.jl
@@ -6,6 +6,8 @@ using Random
 # @reexport using LightGraphs
 import LightGraphs as lg
 
+include("mmdqueues.jl")
+
 include("utils.jl")
 include("graph.jl")
 include("treewidth_heuristics.jl")

--- a/src/VertexEliminationOrders.jl
+++ b/src/VertexEliminationOrders.jl
@@ -2,14 +2,15 @@ module VertexEliminationOrders
 
 using Base.Threads
 using Random
-# using Reexport
-# @reexport using LightGraphs
-import LightGraphs as lg
 
-include("mmdqueues.jl")
+# Sub-modules to support dfs and heuristics.
+include("mmdqueues.jl"); include("graphs.jl")
+using .MMDQueues, .Graphs
+export Graph
 
+# Utility functions for loading and analysing graphs.
 include("utils.jl")
-include("graph.jl")
+
 include("treewidth_heuristics.jl")
 include("dfs_utils.jl")
 include("dfs.jl")

--- a/src/dfs.jl
+++ b/src/dfs.jl
@@ -70,7 +70,7 @@ function bb(state::DFSState, curr_tw::UInt16, v::UInt16)
     if next_tw < state.ub.tw #&& check_lower_bounds!(state, curr_tw)
 
         # Eliminate the vertex from the current graph.
-        edges_added = eliminate!(state, v)
+        eliminate!(state, v)
         state.nodes_visited += 1
         
         if check_lower_bounds!(state, next_tw)
@@ -78,7 +78,7 @@ function bb(state::DFSState, curr_tw::UInt16, v::UInt16)
         end
         
         # Restore the graph to its original state before returning.
-        restore_last_eliminated!(state, edges_added)
+        restore_last_eliminated!(state)
     else
         if curr_tw >= state.ub.tw
             state.ub_prune_at_depth[state.depth] += 1

--- a/src/dfs.jl
+++ b/src/dfs.jl
@@ -154,7 +154,7 @@ end
 function check_lower_bounds!(state::DFSState, curr_tw::UInt16)
     # Compute a lower bound on the remaining graph and prune if
     # it is equal or larger than the current upper bound. 
-    if mmd(state.graph) >= state.ub.tw
+    if mmd(state) >= state.ub.tw
         state.mmd_prune_at_depth[state.depth] += 1
         return false
     end

--- a/src/dfs_utils.jl
+++ b/src/dfs_utils.jl
@@ -18,7 +18,7 @@ end
 function initialise_upper_bound(G::lg.AbstractGraph, seed::Integer)
     initial_ub_order, initial_ub_tw = min_fill(G; seed=seed)
     initial_ub = UpperBound(initial_ub_tw, initial_ub_order, SpinLock())
-    println("The initial treewidth is ", initial_ub_tw)
+    @info "The initial treewidth is $initial_ub_tw"
     initial_ub
 end
 
@@ -89,10 +89,10 @@ function initialise_dfsstates(G::lg.AbstractGraph,
     # Create a search state for each thread.
     lbs = LowerBounds()
     state = DFSState(Graph(G), ub, lbs, finish_time, seed)
-    [copy(state, seed + t) for t = 1:n], 0x0000
+    [copy(state, seed + t) for t = 1:n]
 end
 
-function prep_state!(state::DFSState, run_time)
+function prep_state!(state::DFSState, run_time::AbstractFloat)::Nothing
     state.finish_time = time() + run_time
     state.space_covered = 0.0
     state.timed_out = false
@@ -198,7 +198,7 @@ function Base.show(io::IO, r::DFSReport)
         println(io, " allocated   = ", r.duration)
         println(io, " actual      = ", r.actual_time)
         println(io, " heuristic   = ", r.heuristic_time)
-        println(io, " main run    = ", r.dfs_time)
+        println(io, " b&b dfs     = ", r.dfs_time)
     else
         show(io, (r.best_tw, r.best_order))
     end

--- a/src/dfs_utils.jl
+++ b/src/dfs_utils.jl
@@ -209,9 +209,8 @@ end
 
 Restores a vertex 'v' which was eliminated to form the given 'state'.
 """
-function Graphs.restore_last_eliminated!(state::DFSState,
-                                   edges_to_remove::Vector{Tuple{UInt16, UInt16}})
-    restore_last_eliminated!(state.graph, edges_to_remove)
+function Graphs.restore_last_eliminated!(state::DFSState)
+    restore_last_eliminated!(state.graph)
     v = state.graph.vertices[state.graph.num_vertices]
     state.intermediate_graph_key[v] = false
     nothing

--- a/src/dfs_utils.jl
+++ b/src/dfs_utils.jl
@@ -42,7 +42,6 @@ mutable struct DFSState
     branches::Vector{Vector{UInt16}}   # A vector of vetrices to search for each node depth
 
     pq::MMDQueue                       #
-    I::Vector{UInt16}                  # 
 
     # Some varibales to record where pruning happends (for introspection)
     lbs_prune_at_depth::Vector{UInt64}
@@ -66,11 +65,10 @@ function DFSState(g::Graph, ub::UpperBound, lbs::LowerBounds, finish_time::Float
 
     branches = [Vector{UInt16}(undef, N-i) for i = 0:N-2]
 
-    pq = MMDQueue(g.vertices, g.degree) 
-    I = similar(g.degree)
+    pq = MMDQueue(g.vertices, g.degree)
 
     DFSState(g, N, falses(N),
-             initial_curr_order, ub, lbs, branches, pq, I,
+             initial_curr_order, ub, lbs, branches, pq,
              zeros(UInt64, N), zeros(UInt64, N), zeros(UInt64, N), 
              finish_time, false, 0.0, 0, 1, rng)
 end
@@ -78,7 +76,7 @@ end
 """Return a copy of the given DFSState."""
 function Base.copy(s::DFSState, seed::Int=42)
     DFSState(deepcopy(s.graph), s.N, copy(s.intermediate_graph_key),
-             copy(s.curr_order), s.ub, s.lbs, deepcopy(s.branches), deepcopy(s.pq), copy(s.I),
+             copy(s.curr_order), s.ub, s.lbs, deepcopy(s.branches), deepcopy(s.pq),
              zeros(UInt64, s.N), zeros(UInt64, s.N), zeros(UInt64, s.N),
              s.finish_time, false, 0.0, 0, s.depth, MersenneTwister(seed))
 end
@@ -207,10 +205,6 @@ function mmd(state::DFSState)
     g = state.graph
     verts = vertices(g)
 
-    I = @view state.I[1:g.num_vertices]
-    by(v) = g.degree[v]
-    sortperm!(I, verts; by=by, alg=QuickSort)
-
-    initialise_mmdqueue!(state.pq, I, verts, g.degree)
+    initialise_mmdqueue!(state.pq, verts, g.degree)
     mmd(state.graph, state.pq)
 end

--- a/src/dfs_utils.jl
+++ b/src/dfs_utils.jl
@@ -17,7 +17,7 @@ end
 """Use a heuristic to get an initial upper bound on the treewidth."""
 function initialise_upper_bound(G::lg.AbstractGraph)
     # initial_ub_order, initial_ub_tw = min_fill(G; seed=seed)
-    initial_ub_order, initial_ub_tw = collect(1:lg.nv(G)), 500
+    initial_ub_order, initial_ub_tw = collect(1:lg.nv(G)), 100
     initial_ub = UpperBound(initial_ub_tw, initial_ub_order, SpinLock())
     println("The initial treewidth is ", initial_ub_tw)
     initial_ub

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -1,0 +1,192 @@
+export Graph, neighbourhood, degree
+
+mutable struct Graph
+    num_vertices::UInt16
+    vertices::Vector{UInt16}
+
+    degree::Vector{UInt16}
+    neighbours::Vector{Vector{UInt16}}
+
+    simplexity::Vector{Vector{Tuple{UInt16, UInt16}}} # edges that need to be added to turn neighbourhood of vertex into a simplex.
+end
+
+function Graph(G::lg.SimpleGraph)
+    num_vertices = lg.nv(G)
+    vertices = lg.vertices(G)
+
+    degree = lg.degree(G)
+
+    neighbours = [Array{UInt16, 1}(undef, num_vertices-1) for i = 1:num_vertices]
+    for v = 1:num_vertices
+        neighbours[v][1:degree[v]] = lg.all_neighbors(G, v)
+    end
+
+    simplexity = [Tuple{UInt16, UInt16}[] for v = 1:num_vertices]
+    for v = 1:num_vertices
+        for ni = 1:degree[v]-1
+            for nj = ni+1:degree[v]
+                ui = neighbours[v][ni]
+                uj = neighbours[v][nj]
+                if !lg.has_edge(G, ui, uj)
+                    edge = ui < uj ? (ui, uj) : (uj, ui)
+                    push!(simplexity[v], edge)
+                end
+            end
+        end
+    end
+
+    Graph(num_vertices, vertices, degree, neighbours, simplexity)
+end
+
+function Base.show(io::IO, g::Graph)
+    compact = get(io, :compact, false)
+    if !compact
+        println(io, "The graph has ", g.num_vertices, " nodes")
+        println(io, "and ", Int(sum(g.degree[g.vertices[1:g.num_vertices]])/2), " edges.")
+    end
+end
+
+vertices(g::Graph) = @view g.vertices[1:g.num_vertices]
+neighbourhood(g::Graph, v::Integer) = @view g.neighbours[v][1:g.degree[v]]
+degree(g::Graph, v::Integer) = g.degree[v]
+
+function remove_vertex!(g::Graph, v::UInt16)
+    # This assumes v is a vertex of g. who knows what happens if it isn't.
+
+    # Find where v is in the vertices array.
+    i = 1
+    while g.vertices[i] != v
+        i += 1
+    end
+
+    # Swap v with the n-th vertex and decrease n by 1.
+    g.vertices[i] = g.vertices[g.num_vertices]
+    g.vertices[g.num_vertices] = v
+    g.num_vertices -= 1
+
+    # Remove v from the neighbourhood of its neighbours.
+    for n in neighbourhood(g, v)
+        i = 1
+        N = neighbourhood(g, n)
+        while N[i] != v
+            i += 1
+        end
+
+        N[i] = N[end]
+        g.degree[n] -= 1
+
+        # Remove edges from simplexity of n if it contains v
+        filter!(edge -> !(v in edge), g.simplexity[n])
+    end
+
+    nothing
+end
+
+function add_edge!(g::Graph, u::UInt16, v::UInt16)
+    # This assumes u is less than v and that the edge (u, v) doesn't already exist.
+
+    # Update the simplexity of common neighbours of u and v.
+    Nv = neighbourhood(g, v)
+    Nu = neighbourhood(g, u)
+    for n in Nu
+        if n in Nv
+            println(u, " and ", v, " affecting ", n)
+            # remove (u, v) from simplexity[n]
+            i = 1
+            while g.simplexity[n][i] != (u, v)
+                i += 1
+            end
+            deleteat!(g.simplexity[n], i)
+        end
+    end
+
+    for n in Nu
+        if !(v in g.neighbours[n])
+            edge = n < v ? (n, v) : (v, n)
+            push!(g.simplexity[u], edge)
+        end
+    end
+
+    for n in Nv
+        if !(u in g.neighbours[n])
+            edge = n < u ? (n, u) : (u, n)
+            push!(g.simplexity[v], edge)
+        end
+    end
+
+    # Increment the degrees of u and v.
+    g.degree[u] += 1
+    g.degree[v] += 1
+
+    # Add v as a neighbour of u and vice versa.
+    g.neighbours[u][g.degree[u]] = v
+    g.neighbours[v][g.degree[v]] = u
+
+    nothing
+end
+
+function remove_edge!(g::Graph, u::UInt16, v::UInt16)
+    # This assumes u < v.
+    i = 1
+    while g.neighbours[u][i] != v
+        i += 1
+    end
+    g.neighbours[u][i] = g.neighbours[u][g.degree[u]]
+    g.degree[u] -= 1
+
+    i = 1
+    while g.neighbours[v][i] != u
+        i += 1
+    end
+    g.neighbours[v][i] = g.neighbours[v][g.degree[v]]
+    g.degree[v] -= 1
+
+    # Update simplexity of neighbours.
+    Nv = neighbourhood(g, v)
+    Nu = neighbourhood(g, u)
+    for n in Nu
+        if n in Nv
+            push!(g.simplexity[n], (u, v))
+        end
+    end
+
+    for n in Nu
+        filter!(e -> !(v in e), g.simplexity[n])
+    end
+    for n in Nv
+        filter!(e -> !(u in e), g.simplexity[n])
+    end
+
+    nothing
+end
+
+function make_simplicial!(g::Graph, v::UInt16)
+    for (ui, uj) in g.simplexity[v]
+        println("adding ", ui, " and ", uj)
+        add_edge!(g, ui, uj)
+    end
+    nothing
+end
+
+function eliminate!(g::Graph, v::UInt16)
+    remove_vertex!(g, v)
+    make_simplicial!(g, v)
+
+    nothing
+end
+
+function restore_last_eliminated!(g::Graph)
+    # I think the simplexity is incorrectly updated here
+    # Should be an update for every edge connecting v
+    g.num_vertices += 1
+    v = g.vertices[g.num_vertices]
+
+    for n in neighbourhood(g, v)
+        g.degree[n] += 1
+        g.neighbours[n][g.degree[n]] = v
+    end
+
+    for (ui, uj) in g.simplexity[v]
+        remove_edge!(g, ui, uj)
+    end
+end

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -1,8 +1,75 @@
 module Graphs
 
+#=
+This module defines a custom graph struct, tailored for a depth first 
+search through the set of all vertex elimination orders of a graph.
+It aims to provide graph operations which are central to such a search
+algorithm and which are non-allocating.
+
+The implemented interface allows one to view the current vertices of a 
+graph, the neighbours of a vertex and and its degree. It also enables 
+one to eliminate a vertex and restore the previous vertex which was 
+eliminated.
+=#
+
+#=
+Info on the implementation:
+
+The Graph struct contains the following fields:
+
+    num_vertices - num vertices remaining in the graph.
+    vertices     - a vector to hold remaining and removed vertices.
+    degree       - a vector to hold the degrees of vertices.
+    adj_list     - an adjacency list
+    adj_memory   - a matrix to track which and when edges are added.
+    num_updates  - num updates applied to the graph to get to the 
+                   current state. Initialisation is the first update,
+                   the rest are eliminations.
+
+In a depth first search of vertex elimination orders, after 
+initialisation, various vertices are eliminated from the graph and 
+restored, resulting in various intermediate states.
+
+At any given state, the vertices that remain in the graph are stored
+in the first 'num_vertices' elements of the vector 'vertices'. The
+other elements of this vector maintain the order in which the 
+eliminated vertices were removed.
+
+The connectivity of the remaining vertices is described by the
+adjacency list. Namely, the neighbours of a vertex v in the graph are
+given by 'adj_list[v][1:degree[v]]'. If v is a vertex which was 
+eliminated, then this expression gives the neighbours v had when it
+was eliminated.
+
+When eliminating a vertex, two things happen to facilitate the 
+restoration of previously eliminated vertices:
+
+    1) a counter is incremented to track the number of updates made 
+       to the graph to get to the current state.
+
+    2) elements of a matrix, called adjacency memory matrix, are updated
+       to record which edges were added to make the vertex simplicial and
+       which update these edges were added in.
+
+The adjacency memory matrix is similar to an adjacency matrix but not
+equivalent. It not only contains information regarding the current connectivity
+of the graph but also temporal information about when certain edges were added
+to the graph. If 'M = adj_memory' and both 'i' and 'j' are remaining vertices
+in the graph, then 'M[i, j] == 0' means there is no edge between 'i' and 'j' 
+while 'M[i, j] == u', where 'u > 0', means there is an edge between them and
+it was aded during update 'u'. Note, the initialisation of the graph is taken
+as update number 1. If either 'i' or 'j' are eliminated, then 'M[i,j]' 
+indicates the state of the associated edge when the earliest of these updates
+happened.
+
+Safety checks, such making sure a vertex isnt already removed before eliminating,
+have been ommitted in the interest of performance and such assumptions are 
+assumed to be guaranteed by the depth first search implementation.
+=#
+
 import LightGraphs as lg
 
-export Graph, vertices, neighbours, neighbourhood, degree, lg
+export Graph, vertices, neighbours, degree, lg
 export eliminate!, restore_last_eliminated!
 
 ###
@@ -17,14 +84,14 @@ mutable struct Graph
     degree::Vector{UInt16}
     adj_list::Vector{Vector{UInt16}}
 
-    adj_matrix::BitMatrix # true -> edge doesn't exists, false -> edge does exists
+    adj_memory::Matrix{UInt16}
+    num_updates::UInt16
 end
 
 """Graph Constructor"""
 function Graph(G::lg.SimpleGraph)
     num_vertices = lg.nv(G)
     vertices = lg.vertices(G)
-
     degree = lg.degree(G)
 
     # Initialise the graphs adjacency list.
@@ -33,17 +100,17 @@ function Graph(G::lg.SimpleGraph)
         adj_list[v][1:degree[v]] = lg.all_neighbors(G, v)
     end
 
-    # Initialise the graphs adjacency matrix.
-    adj_matrix = trues(num_vertices, num_vertices)
+    # Initialise the graphs adjacency memory.
+    adj_memory = zeros(UInt16, num_vertices, num_vertices)
     for v = 1:num_vertices
         for u in adj_list[v][1:degree[v]]
-            adj_matrix[v, u] = false
-            adj_matrix[u, v] = false
+            adj_memory[v, u] = 0x0001
+            adj_memory[u, v] = 0x0001
         end
     end
 
     # Create the graph.
-    Graph(num_vertices, vertices, degree, adj_list, adj_matrix)
+    Graph(num_vertices, vertices, degree, adj_list, adj_memory, 0x0001)
 end
 
 function Base.show(io::IO, g::Graph)
@@ -65,7 +132,7 @@ neighbours(g::Graph, v::Integer) = @view g.adj_list[v][1:g.degree[v]]
 """Return the adjacency matrix of the neighbourhood of v."""
 function neighbourhood(g::Graph, v::Integer)
     N = neighbours(g, v)
-    @view g.adj_matrix[N, N]
+    @view g.adj_memory[N, N]
 end
 
 """Remove a vertex from the graph."""
@@ -78,7 +145,7 @@ function remove_vertex!(g::Graph, v::UInt16)::Nothing
     # Swap v with the n-th vertex and decrease n by 1.
     g.vertices[i] = g.vertices[g.num_vertices]
     g.vertices[g.num_vertices] = v
-    g.num_vertices -= 1
+    g.num_vertices -= 0x0001
 
     # Remove v from the neighbourhood of its neighbours.
     for n in neighbours(g, v)
@@ -86,12 +153,7 @@ function remove_vertex!(g::Graph, v::UInt16)::Nothing
         i = find_index(N, v)
 
         N[i] = N[end]
-        g.degree[n] -= 1
-
-        # Remove edges the adjacency matrix
-        # TODO: only use a triangular matrix.
-        g.adj_matrix[v, n] = true
-        g.adj_matrix[n, v] = true
+        g.degree[n] -= 0x0001
     end
 
     nothing
@@ -100,16 +162,16 @@ end
 """Add an edge to the grapg G connecting u and v."""
 function add_edge!(g::Graph, u::UInt16, v::UInt16)::Nothing
     # Increment the degrees of u and v.
-    g.degree[u] += 1
-    g.degree[v] += 1
+    g.degree[u] += 0x0001
+    g.degree[v] += 0x0001
 
     # Add v as a neighbour of u and vice versa.
     g.adj_list[u][g.degree[u]] = v
     g.adj_list[v][g.degree[v]] = u
 
     # Update adjacency matrix.
-    g.adj_matrix[u, v] = false
-    g.adj_matrix[v, u] = false
+    g.adj_memory[u, v] = g.num_updates
+    g.adj_memory[v, u] = g.num_updates
 
     nothing
 end
@@ -119,59 +181,55 @@ function remove_edge!(g::Graph, u::UInt16, v::UInt16)::Nothing
     # Update adjacency list for u.
     i = find_index(g.adj_list[u], v)
     g.adj_list[u][i] = g.adj_list[u][g.degree[u]]
-    g.degree[u] -= 1
+    g.degree[u] -= 0x0001
 
     # Update adjacency list for v.
     i = find_index(g.adj_list[v], u)
     g.adj_list[v][i] = g.adj_list[v][g.degree[v]]
-    g.degree[v] -= 1
+    g.degree[v] -= 0x0001
 
     # Update adjacency matrix.
-    g.adj_matrix[u, v] = true
-    g.adj_matrix[v, u] = true
+    g.adj_memory[u, v] = 0x0000
+    g.adj_memory[v, u] = 0x0000
 
     nothing
 end
 
 """Get the number of edges that need to be added to make the neighbourhood a simplex."""
 function simplexity(nbhd::SubArray)::Int64
-    count = 0
+    count = 0x0000
     n = size(nbhd)[1]
     for i = 1:n-1
         for j = i+1:n
-            @inbounds count += nbhd[i, j]
+            @inbounds if nbhd[i, j] == 0x0000
+                count += 0x0001
+            end
         end
     end
     count
 end
 
 """Turn the neighbourhood of v into a simplex."""
-function make_simplicial!(g::Graph, v::UInt16)::Vector{Tuple{UInt16, UInt16}}
-
+function make_simplicial!(g::Graph, v::UInt16)::Nothing
     Nbhd = neighbourhood(g, v)
     N = neighbours(g, v)
 
-    # TODO: use a static array here?
-    edges_added = Vector{Tuple{UInt16, UInt16}}(undef, simplexity(Nbhd))
-
     d = g.degree[v]
-    e = 1
     for i = 1:d-1
         for j = i+1:d
-            if Nbhd[i, j]
+            if Nbhd[i, j] == 0x0000
                 @inbounds ui = N[i]; uj = N[j]
-                @inbounds edges_added[e] = (ui, uj)
-                e += 1
                 add_edge!(g, ui, uj)
             end
         end
     end
 
-    edges_added
+    nothing
 end
 
 """Remove the vertex v from the graph g and make it simplicial."""
-function eliminate!(g::Graph, v::UInt16)::Vector{Tuple{UInt16, UInt16}}
+function eliminate!(g::Graph, v::UInt16)::Nothing
+    g.num_updates += 0x0001
     remove_vertex!(g, v)
     make_simplicial!(g, v)
 end
@@ -182,22 +240,29 @@ Add the last vertex to be eliminated back to g and restore its neighbourhood.
 'edges_to_remove' is assumed to contain the edges added to g to make the vertex
 simplicial when being eliminated.
 """
-function restore_last_eliminated!(g::Graph, edges_to_remove::Vector{Tuple{UInt16, UInt16}})::Nothing
-    g.num_vertices += 1
+function restore_last_eliminated!(g::Graph)::Nothing
+    g.num_vertices += 0x0001
     v = g.vertices[g.num_vertices]
+    N = neighbours(g, v)
 
-    for n in neighbours(g, v)
-        g.degree[n] += 1
+    for n in N
+        g.degree[n] += 0x0001
         g.adj_list[n][g.degree[n]] = v
-
-        g.adj_matrix[v, n] = false
-        g.adj_matrix[n, v] = false
     end
 
-    for (ui, uj) in edges_to_remove
-        remove_edge!(g, ui, uj)
+    Nbhd = neighbourhood(g, v)
+    d = g.degree[v]
+    for i = 1:d-1
+        for j = i+1:d
+            if Nbhd[i, j] == g.num_updates
+                @inbounds ui = N[i]; uj = N[j]
+                remove_edge!(g, ui, uj)
+            end
+        end
     end
     
+    g.num_updates -= 0x0001
+
     nothing
 end
 
@@ -208,7 +273,7 @@ end
 """Get the index of a value v in an array A"""
 function find_index(A::AbstractVector{T}, v::T)::Int64 where T
     i = 1
-    while A[i] != v
+    @inbounds while A[i] != v
         i += 1
     end
     i

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -144,12 +144,12 @@ function remove_vertex!(g::Graph, v::UInt16)::Nothing
     i = find_index(g.vertices, v)
 
     # Swap v with the n-th vertex and decrease n by 1.
-    g.vertices[i] = g.vertices[g.num_vertices]
-    g.vertices[g.num_vertices] = v
+    @inbounds g.vertices[i] = g.vertices[g.num_vertices]
+    @inbounds g.vertices[g.num_vertices] = v
     g.num_vertices -= 0x0001
 
     # Remove v from the neighbourhood of its neighbours.
-    for n in neighbours(g, v)
+    @inbounds for n in neighbours(g, v)
         N = neighbours(g, n)
         i = find_index(N, v)
 
@@ -163,16 +163,16 @@ end
 """Add an edge to the grapg G connecting u and v."""
 function add_edge!(g::Graph, u::UInt16, v::UInt16)::Nothing
     # Increment the degrees of u and v.
-    g.degree[u] += 0x0001
-    g.degree[v] += 0x0001
+    @inbounds g.degree[u] += 0x0001
+    @inbounds g.degree[v] += 0x0001
 
     # Add v as a neighbour of u and vice versa.
-    g.adj_list[u][g.degree[u]] = v
-    g.adj_list[v][g.degree[v]] = u
+    @inbounds g.adj_list[u][g.degree[u]] = v
+    @inbounds g.adj_list[v][g.degree[v]] = u
 
     # Update adjacency matrix.
-    g.adj_memory[u, v] = g.num_updates
-    g.adj_memory[v, u] = g.num_updates
+    @inbounds g.adj_memory[u, v] = g.num_updates
+    @inbounds g.adj_memory[v, u] = g.num_updates
 
     nothing
 end
@@ -181,17 +181,17 @@ end
 function remove_edge!(g::Graph, u::UInt16, v::UInt16)::Nothing
     # Update adjacency list for u.
     i = find_index(g.adj_list[u], v)
-    g.adj_list[u][i] = g.adj_list[u][g.degree[u]]
-    g.degree[u] -= 0x0001
+    @inbounds g.adj_list[u][i] = g.adj_list[u][g.degree[u]]
+    @inbounds g.degree[u] -= 0x0001
 
     # Update adjacency list for v.
-    i = find_index(g.adj_list[v], u)
-    g.adj_list[v][i] = g.adj_list[v][g.degree[v]]
-    g.degree[v] -= 0x0001
+    @inbounds i = find_index(g.adj_list[v], u)
+    @inbounds g.adj_list[v][i] = g.adj_list[v][g.degree[v]]
+    @inbounds g.degree[v] -= 0x0001
 
     # Update adjacency matrix.
-    g.adj_memory[u, v] = 0x0000
-    g.adj_memory[v, u] = 0x0000
+    @inbounds g.adj_memory[u, v] = 0x0000
+    @inbounds g.adj_memory[v, u] = 0x0000
 
     nothing
 end
@@ -251,7 +251,7 @@ function restore_last_eliminated!(g::Graph)::Nothing
     v = g.vertices[g.num_vertices]
     N = neighbours(g, v)
 
-    for n in N
+    @inbounds for n in N
         g.degree[n] += 0x0001
         g.adj_list[n][g.degree[n]] = v
     end

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -69,7 +69,7 @@ assumed to be guaranteed by the depth first search implementation.
 
 import LightGraphs as lg
 
-export Graph, vertices, neighbours, degree, lg
+export Graph, num_vertices, vertices, neighbours, degree, lg
 export eliminate!, restore_last_eliminated!
 
 ###
@@ -126,6 +126,7 @@ end
 ###
 
 degree(g::Graph, v::Integer) = g.degree[v]
+num_vertices(g::Graph) = g.num_vertices
 vertices(g::Graph) = @view g.vertices[1:g.num_vertices]
 neighbours(g::Graph, v::Integer) = @view g.adj_list[v][1:g.degree[v]]
 

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -3,8 +3,8 @@ module Graphs
 #=
 This module defines a custom graph struct, tailored for a depth first 
 search through the set of all vertex elimination orders of a graph.
-It aims to provide graph operations which are central to such a search
-algorithm and which are non-allocating.
+It aims to provide graph operations which are both central to such a 
+search algorithm and are non-allocating.
 
 The implemented interface allows one to view the current vertices of a 
 graph, the neighbours of a vertex and and its degree. It also enables 
@@ -210,7 +210,10 @@ function simplexity(nbhd::SubArray)::Int64
     count
 end
 
-"""Turn the neighbourhood of v into a simplex."""
+"""
+Turn the neighbourhood of v into a simplex.
+The number of edges added to do so is also returned.
+"""
 function make_simplicial!(g::Graph, v::UInt16)::UInt16
     Nbhd = neighbourhood(g, v)
     N = neighbours(g, v)

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -211,25 +211,27 @@ function simplexity(nbhd::SubArray)::Int64
 end
 
 """Turn the neighbourhood of v into a simplex."""
-function make_simplicial!(g::Graph, v::UInt16)::Nothing
+function make_simplicial!(g::Graph, v::UInt16)::UInt16
     Nbhd = neighbourhood(g, v)
     N = neighbours(g, v)
 
     d = g.degree[v]
+    e = 0
     for i = 1:d-1
         for j = i+1:d
             if Nbhd[i, j] == 0x0000
                 @inbounds ui = N[i]; uj = N[j]
                 add_edge!(g, ui, uj)
+                e += 0x0001
             end
         end
     end
 
-    nothing
+    e
 end
 
 """Remove the vertex v from the graph g and make it simplicial."""
-function eliminate!(g::Graph, v::UInt16)::Nothing
+function eliminate!(g::Graph, v::UInt16)::UInt16
     g.num_updates += 0x0001
     remove_vertex!(g, v)
     make_simplicial!(g, v)

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -1,4 +1,9 @@
-export Graph, neighbours, neighbourhood, degree
+module Graphs
+
+import LightGraphs as lg
+
+export Graph, vertices, neighbours, neighbourhood, degree, lg
+export eliminate!, restore_last_eliminated!
 
 ###
 ### Graph struct
@@ -207,4 +212,6 @@ function find_index(A::AbstractVector{T}, v::T)::Int64 where T
         i += 1
     end
     i
+end
+
 end

--- a/src/mmdqueues.jl
+++ b/src/mmdqueues.jl
@@ -81,8 +81,8 @@ function initialise_mmdqueue!(pq::MMDQueue,
 
     # Initialise the queue.
     for i = 0x0001:N
-        vi = vertices[i]
-        queue[i] = vi => degrees[vi]
+        @inbounds vi = vertices[i]
+        @inbounds queue[i] = vi => degrees[vi]
     end
 
     # Sort the queue (Use quicksort as it's non-allocating).
@@ -91,7 +91,7 @@ function initialise_mmdqueue!(pq::MMDQueue,
 
     # Initialise keys and bag structure
     bag = 0x0000
-    for i = 0x0001:N
+    @inbounds for i = 0x0001:N
         (v, d) = queue[i]
         keys[v] = i
 
@@ -112,9 +112,9 @@ Return the element with highest priority and increment all
 bag boundaries to point to the next highest priority element.
 """
 function pull!(q::MMDQueue)
-    p = q.queue[q.min]
+    @inbounds p = q.queue[q.min]
     q.min += 0x0001
-    q.bags[0x0001:p.second+0x0001] .= q.min
+    @inbounds q.bags[0x0001:p.second+0x0001] .= q.min
     p
 end
 
@@ -158,8 +158,8 @@ the correct priority for vertices and bag structure.
 See comments above docstring for implementation details.
 """
 function decrement!(q::MMDQueue, v::UInt16)
-    i = q.keys[v]           # index of v.
-    if i >= q.min
+    @inbounds i = q.keys[v]           # index of v.
+    @inbounds if i >= q.min
         d = q.queue[i].second   # the degree of v.
         b = q.bags[d + 0x0001]  # index of bag d boundary.
 

--- a/src/mmdqueues.jl
+++ b/src/mmdqueues.jl
@@ -85,7 +85,7 @@ function initialise_mmdqueue!(pq::MMDQueue,
         queue[i] = vi => degrees[vi]
     end
 
-    # Sort the queue.
+    # Sort the queue (Use quicksort as it's non-allocating).
     q = @view queue[0x0001:N]
     sort!(q; alg=QuickSort, by=p -> p.second)
 

--- a/src/mmdqueues.jl
+++ b/src/mmdqueues.jl
@@ -1,0 +1,227 @@
+module MMDQueues
+
+# TODO: I don't think the extra slot at the end of the queue is needed anymore.
+
+#=
+This module defines a custom priority queue optimised for implementing 
+the mmd heuristic.
+
+Retrieving the highest priority element and decrementing the priority
+of elements by 1 are both order 1 operations in complextity. mmd does
+not need an insertion operation so it can be omitted.
+
+The queue is represented by a sorted array of (vertex, degree) pairs.
+An array of keys or indices for the vertices is maintained for order
+1 look up of a vertex in the queue.
+
+A bag structure is also maintained to help keep the queue sorted
+when the degree of a vertex is decremented. ie. the queue is 
+partitioned into bags, with all vertices in bag d having degree d.
+This is maintained by an array containing the positions of the left
+most boundary of a bag. The vertices of degree d begin at bags[d+1]
+inclusively and end at bags[d+2] exclusively.
+
+
+            Bag 0 <----- empty Bags ------>  Bag 3
+            |___|                            |___|
+              |--Bag 1-|-------Bag 2-----------|--Bag 4-|--Bag 5-|
+              |        |                       |        |        |       
+              |        |                       |        |        |
+queue: [ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ]
+        |  |  |
+        |  |   \__
+removed----       \--min
+=#
+
+export MMDQueue, pop!, decrement!
+
+"""
+A custom priority queue optimised for implementing the mmd heuristic.
+
+Retrieving the highest priority element and decrementing the priority
+of elements by 1 are both order 1 operations in complextity. mmd does
+not need an insertion operation so it can be omitted.
+
+See comments above docstring for implementation details.
+"""
+mutable struct MMDQueue
+    queue::Vector{Pair{UInt16, UInt16}}
+    keys::Vector{UInt16}
+    bags::Vector{UInt16}
+    min::UInt16
+end
+
+function MMDQueue(vertices::Vector{UInt16}, degrees::Vector{UInt16})
+    I = sortperm(vertices; by=v -> degrees[v])
+    N = length(vertices)
+
+    queue = Array{Pair{UInt16, UInt16}, 1}(undef, N+1)
+    keys = similar(vertices)
+    bags = fill(UInt16(N+1), N)
+
+    bag = 0
+    for (i, vi) in enumerate(I)
+        v = vertices[vi]
+        d = degrees[v]
+        queue[i] = Pair(v, d)
+        keys[v] = i
+
+        if d >= bag
+            bags[bag+1:d+1] .= i
+            bag = d + 1
+        end
+    end
+
+    MMDQueue(queue, keys, bags, 0x0001)
+end
+
+"""
+    pop!(q::MMDQueue)
+
+Return the element with highest priority and increment all
+bag boundaries to point to the next highest priority element.
+"""
+function pop!(q::MMDQueue)
+    p = q.queue[q.min]
+    q.min += 0x0001
+    q.bags[0x0001:p.second+0x0001] .= q.min
+    p
+end
+
+#=
+decrement! is implemented by swapping v, in bag d, with the vertex 
+at the boundary of bag d. The degree of v is decremented and the 
+boundary of bag d is incremented so that v is no longer in bag d 
+and now in bag d - 1.
+
+Example:
+
+Initial state: 
+               ---to swap --
+               |           |
+               |           |
+degree: [ ][ ][ ][ ][ ][ ][d][ ][ ]
+queue : [ ][ ][p][ ][ ][ ][v][ ][ ]
+bags  : [ ][b][ ][ ][ ][ ][ ][ ][ ]
+keys  : [ ][ ][ ][ ][i][ ][ ][ ][ ]
+ind   :     d  b     v     i
+
+
+Final state: (D = d - 1, B = b + 1)
+
+                  --- new boundary of bag d
+                  |
+                  |
+degree: [ ][ ][D][|][ ][ ][ ][ ][ ]
+queue : [ ][ ][v][|][ ][ ][p][ ][ ]
+bags  : [ ][B][ ][|][ ][ ][ ][ ][ ]
+keys  : [ ][ ][ ][|][b][ ][ ][ ][ ]
+ind   :     d  b  |  v     i
+=#
+
+"""
+    decrement!(q::MMDQueue, v::UInt16)
+
+Decrease the degree of v by 1 and update the queue to maintain
+the correct priority for vertices and bag structure.
+
+See comments above docstring for implementation details.
+"""
+function decrement!(q::MMDQueue, v::UInt16)
+    i = q.keys[v]           # index of v.
+    if i >= q.min
+        d = q.queue[i].second   # the degree of v.
+        b = q.bags[d + 0x0001]  # index of bag d boundary.
+
+        # Move the pair at the boundary to where v was.
+        p = q.queue[b]
+        q.queue[i] = p
+        q.keys[p.first] = i
+
+        # Place new pair for v at the boundary and
+        # increment the boundary position.
+        q.queue[b] = v => d - 0x0001
+        q.keys[v] = b
+        q.bags[d + 0x0001] += 0x0001
+    end
+
+    nothing
+end
+
+###
+### Base.show implementation for MMDQueues.
+###
+
+function Base.show(io::IO, q::MMDQueue)
+    if length(q.queue) <= 32
+        show_verbose(io, q)
+    else
+        show_compact(io, q)
+    end
+end
+
+"""
+Print some of the fields of the given MMDQueue.
+"""
+function show_compact(io::IO, q::MMDQueue)
+    ks = [p.first for p in q.queue]
+    ds = [p.second for p in q.queue]
+    println(io, "degree: ", Int.(ds))
+    println(io, "vertex: ", Int.(ks))
+    println(io, "bag   : ", Int.(q.bags))
+    println(io, "key   : ", Int.(q.keys))
+end
+
+"""
+Draw a verbose image of the given MMDQueue.
+"""
+function show_verbose(io::IO, q::MMDQueue)
+    println()
+    bar = "  |  "
+    space = "     "
+
+    # Draw the bag structure of the queue.
+    display_array = -1*ones(Int, length(q.queue))
+    for (i, b) in enumerate(q.bags)
+        display_array[b] = i - 1
+    end
+
+    Bl = ""
+    Bu = ""
+    for i in display_array
+        if i == -1
+            Bl *= space
+            Bu *= space
+        else
+            Bl *= bar
+            Bu *= "  $i  "
+        end
+    end
+
+    println(io, Bu)
+    println(io, Bl)
+
+    # Draw the queue.
+    Q = ""
+    D = ""
+    for i = 1:length(q.queue)
+        v, d = q.queue[i]
+        Q *= "[" * lpad(v, 3) * "]"
+        D *= "[" * lpad(d, 3) * "]"
+    end
+
+    println(io, Q)
+    println(io, D)
+
+    # Draw the arrow pointing to the next item of the queue.
+    m = q.min
+    min_arrow = space^(m - 1) * "  ^  "
+    min_bar   = space^(m - 1) * bar
+    min_base  = space^(m - 1) * " min "
+
+    println(io, min_arrow)
+    println(io, min_bar)
+    println(io, min_base)
+end
+
+end

--- a/src/treewidth_heuristics.jl
+++ b/src/treewidth_heuristics.jl
@@ -42,7 +42,7 @@ function min_fill(rng::AbstractRNG,
         v = rand(rng, candidates)
         tw = max(tw, lg.degree(g, v))
         order[i] = labels[v]
-        eliminate!(g, labels, cliqueness_map, v)
+        lg_eliminate!(g, labels, cliqueness_map, v)
         n -= 1
         i += 1
     end

--- a/src/treewidth_heuristics.jl
+++ b/src/treewidth_heuristics.jl
@@ -1,9 +1,7 @@
-import DataStructures.PriorityQueue
-
 export min_fill, min_width
 export min_width_sampling
 export min_width_mt_sampling
-export mmd, mmd_plus, mmd_plus_correct, mmd2, mmd3
+export mmd
 
 #=
 This file contains heuristic functions for computing upper and lower bounds
@@ -200,73 +198,17 @@ mmd(g::lg.SimpleGraph) = mmd(Graph(g))
 
 """Maximum Minimum Degree"""
 function mmd(g::Graph)
-    degree_map = similar(g.degree)
-    mmd(g, degree_map)
-end
-
-function mmd(g::Graph, degree_map::Vector{UInt16})
-    N = g.num_vertices - 0x0001 # max degree possible. 
-    copy!(degree_map, g.degree)
-
-    for i = g.num_vertices+1:g.num_vertices
-        degree_map[g.vertices[i]] = typemax(UInt16)
-    end
-
-    maxmin = 0x0000
-    while maxmin < N
-        dv, v = findmin(degree_map)
-        maxmin = max(maxmin, dv)
-
-        @inbounds degree_map[v] = typemax(UInt16)
-        for u in neighbours(g, v)
-            @inbounds degree_map[u] -= 0x0001
-        end
-
-        N -= 0x0001
-    end
-
-    maxmin
-end
-
-function mmd2(g::Graph)
-    pq = PriorityQueue{UInt16, UInt16}(g.vertices .=> g.degree)
-    mmd2(g, pq)
-end
-
-function mmd2(g::Graph, pq::PriorityQueue{UInt16, UInt16})
-    N = g.num_vertices - 0x0001 # max degree possible. 
-
-    maxmin = 0x0000
-    while maxmin < N
-        @inbounds v_d = pq.xs[1]
-        maxmin = max(maxmin, v_d.second)
-
-        pq[v_d.first] = typemax(UInt16)
-        for u in neighbours(g, v_d.first)
-            pq[u] -= 0x0001
-        end
-
-        N -= 0x0001
-    end
-
-    maxmin
-end
-
-# include("mmd_queue.jl")
-using .MMDQueues
-
-function mmd3(g::Graph)
     pq = MMDQueue(g.vertices, g.degree)
-    mmd3(g, pq)
+    mmd(g, pq)
 end
 
-function mmd3(g::Graph, pq::MMDQueue)
+function mmd(g::Graph, pq::MMDQueue)
     N = g.num_vertices - 0x0001 # max degree possible. 
 
     maxmin = 0x0000
     i = 1
     while maxmin < N
-        @inbounds v_d = pop!(pq)
+        @inbounds v_d = pull!(pq)
         maxmin = max(maxmin, v_d.second)
 
         for u in neighbours(g, v_d.first)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,7 +52,7 @@ end
 
 Return the treewidth of `G` with respect to the elimination order in `order`.
 """
-function find_treewidth_from_order(G::lg.AbstractGraph, order::Array{Int, 1})
+function find_treewidth_from_order(G::lg.AbstractGraph, order::Array{<:Integer, 1})
     G = deepcopy(G)
     labels = collect(1:lg.nv(G))
     τ = 0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,12 +18,12 @@ function graph_from_gr(filename::String)
 
     # Create a Graph with the correct number of vertices.
     num_vertices = parse.(Int, split(lines[1], ' ')[3])
-    G = SimpleGraph(num_vertices)
+    G = lg.SimpleGraph(num_vertices)
 
     # Add an edge to the graph for every other line in the file.
     for line in lines[2:end]
         src, dst = parse.(Int, split(line, ' '))
-        add_edge!(G, src, dst)
+        lg.add_edge!(G, src, dst)
     end
 
     G
@@ -34,179 +34,179 @@ end
 
 Write the provided graph to a file in gr format.
 """
-function graph_to_gr(G::AbstractGraph, filename::String)
+function graph_to_gr(G::lg.AbstractGraph, filename::String)
     open(filename, "w") do io
         write(io, "p tw $(nv(G)) $(ne(G))\n")
-        for e in edges(G)
+        for e in lg.edges(G)
             write(io, "$(e.src) $(e.dst)\n")
         end
     end
 end
 
 
-###
-### functions to analyse elimination orders.
-###
+# ###
+# ### functions to analyse elimination orders.
+# ###
 
-"""
-    find_treewidth_from_order(G::AbstractGraph, order::Array{Symbol, 1})
+# """
+#     find_treewidth_from_order(G::AbstractGraph, order::Array{Symbol, 1})
 
-Return the treewidth of `G` with respect to the elimination order in `order`.
-"""
-function find_treewidth_from_order(G::AbstractGraph, order::Array{Int, 1})
-    G = deepcopy(G)
-    labels = collect(1:nv(G))
-    τ = 0
-    for v_label in order
-        v = findfirst(vl -> vl == v_label, labels)
-        τ = max(τ, degree(G, v))
-        eliminate!(G, labels, v)
+# Return the treewidth of `G` with respect to the elimination order in `order`.
+# """
+# function find_treewidth_from_order(G::lg.AbstractGraph, order::Array{Int, 1})
+#     G = deepcopy(G)
+#     labels = collect(1:nv(G))
+#     τ = 0
+#     for v_label in order
+#         v = findfirst(vl -> vl == v_label, labels)
+#         τ = max(τ, degree(G, v))
+#         eliminate!(G, labels, v)
 
-        lb = mmd_plus(G)
-        if lb >= 7
-            println("Oops: lb is ", lb)
-        end
-    end
-    τ
-end
-
-
-###
-### Functions to analyse a graph.
-###
-
-"""Return a vector containing the similar groups of G as defined by Yaun_2011"""
-function find_similar_groups(G::SimpleGraph{Int})
-    groups = Vector{Int}[]
-    for v in vertices(G)
-        v_in_a_group = false
-        for group in groups
-            if are_similar(G, group[1], v)
-                push!(group, v)
-                v_in_a_group = true
-                break
-            end
-        end
-        v_in_a_group || push!(groups, [v])
-    end
-
-    groups
-end
-
-function are_similar(G::SimpleGraph, u::Int, v::Int)
-    return Set(setdiff(all_neighbors(G, u), [v])) == Set(setdiff(all_neighbors(G, v), [u]))
-end
-
-"""
-    cliqueness(G::AbstractGraph, v::Integer)
-
-Return the number of edges that need to be added to `G` in order to make the neighborhood of 
-vertex `v` a clique.
-"""
-function cliqueness(g::AbstractGraph, v::Integer)::Int
-    neighborhood = all_neighbors(g, v)::Array{Int64, 1}
-    count = 0
-    for i in 1:length(neighborhood)-1
-        for j in i+1:length(neighborhood)
-            vi = neighborhood[i]
-            ui = neighborhood[j]
-            if !has_edge(g, ui, vi)::Bool
-                count += 1
-            end
-        end
-    end
-    count
-end
+#         lb = mmd_plus(G)
+#         if lb >= 7
+#             println("Oops: lb is ", lb)
+#         end
+#     end
+#     τ
+# end
 
 
-###
-### Functions to modify a graph.
-###
+# ###
+# ### Functions to analyse a graph.
+# ###
 
-"""
-    eliminate!(graph, labels, vertex)
+# """Return a vector containing the similar groups of G as defined by Yaun_2011"""
+# function find_similar_groups(G::SimpleGraph{Int})
+#     groups = Vector{Int}[]
+#     for v in vertices(G)
+#         v_in_a_group = false
+#         for group in groups
+#             if are_similar(G, group[1], v)
+#                 push!(group, v)
+#                 v_in_a_group = true
+#                 break
+#             end
+#         end
+#         v_in_a_group || push!(groups, [v])
+#     end
 
-Connects the neighbours of the given vertex into a clique before removing 
-it from the graph.
+#     groups
+# end
 
-The array of vertex labels are also updated to reflect the 
-reording of vertex indices when the graph is updated.
-"""
-function eliminate!(g::AbstractGraph, labels, v)
-    Nᵥ = all_neighbors(g, v)::Array{Int64, 1}
-    for i = 1:length(Nᵥ)-1
-        vi = Nᵥ[i]
-        for j = i+1:length(Nᵥ)
-            vj = Nᵥ[j]
-            add_edge!(g, vi, vj)
-        end
-    end
+# function are_similar(G::SimpleGraph, u::Int, v::Int)
+#     return Set(setdiff(all_neighbors(G, u), [v])) == Set(setdiff(all_neighbors(G, v), [u]))
+# end
 
-    rem_vertex!(g, v)
-    labels[v] = labels[end]
-    pop!(labels)
-    g
-end
+# """
+#     cliqueness(G::AbstractGraph, v::Integer)
 
-"""
-    eliminate!(graph, labels, vertex)
+# Return the number of edges that need to be added to `G` in order to make the neighborhood of 
+# vertex `v` a clique.
+# """
+# function cliqueness(g::AbstractGraph, v::Integer)::Int
+#     neighborhood = all_neighbors(g, v)::Array{Int64, 1}
+#     count = 0
+#     for i in 1:length(neighborhood)-1
+#         for j in i+1:length(neighborhood)
+#             vi = neighborhood[i]
+#             ui = neighborhood[j]
+#             if !has_edge(g, ui, vi)::Bool
+#                 count += 1
+#             end
+#         end
+#     end
+#     count
+# end
 
-Connects the neighbours of the given vertex into a clique before removing 
-it from the graph.
 
-The arrays of vertex labels and cliqueness are also updated to reflect the 
-reording of vertex indices when the graph is updated.
-"""
-function eliminate!(g::AbstractGraph, labels, c_map, v)
-    Nᵥ = all_neighbors(g, v)::Array{Int64, 1}
-    for i = 1:length(Nᵥ)-1
-        vi = Nᵥ[i]
-        for j = i+1:length(Nᵥ)
-            vj = Nᵥ[j]
+# ###
+# ### Functions to modify a graph.
+# ###
 
-            # Try add an edge connecting vi and ui. If successful, update `c_map`.
-            edge_added = add_edge!(g, vi, vj)
-            if edge_added
-                # Common neighbours of vi and vj have one less edge to add
-                # when being eliminated after vi and ui are connected.
-                Nvi = all_neighbors(g, vi)::Array{Int64, 1}
-                Nvj = all_neighbors(g, vj)::Array{Int64, 1}
-                for n in Nvi
-                    if n in Nvj
-                        c_map[n] -= 1
-                    end
-                end
+# """
+#     eliminate!(graph, labels, vertex)
 
-                # ui and vi are now neighbours so their cliqueness may increase.
-                for n in Nvi
-                    if !(n == vj) && !(has_edge(g, n, vj)::Bool)
-                        c_map[vi] += 1
-                    end
-                end
-                for n in Nvj
-                    if !(n == vi) && !(has_edge(g, n, vi)::Bool)
-                        c_map[vj] += 1
-                    end
-                end
-            end
-        end
-    end
+# Connects the neighbours of the given vertex into a clique before removing 
+# it from the graph.
 
-    # Removing v from G means it's also removed from its neighbour's neighbourhood, so their 
-    # cliqueness may be reduced.
-    for n in Nᵥ
-        Nₙ = all_neighbors(g, n)::Array{Int64, 1}
-        for u in Nₙ
-            if !(u == v)
-                if !has_edge(g, v, u)
-                    c_map[n] -= 1
-                end
-            end
-        end
-    end
+# The array of vertex labels are also updated to reflect the 
+# reording of vertex indices when the graph is updated.
+# """
+# function eliminate!(g::AbstractGraph, labels, v)
+#     Nᵥ = all_neighbors(g, v)::Array{Int64, 1}
+#     for i = 1:length(Nᵥ)-1
+#         vi = Nᵥ[i]
+#         for j = i+1:length(Nᵥ)
+#             vj = Nᵥ[j]
+#             add_edge!(g, vi, vj)
+#         end
+#     end
 
-    rem_vertex!(g, v)
-    c_map[v] = c_map[end]
-    labels[v] = labels[end]
-    g
-end
+#     rem_vertex!(g, v)
+#     labels[v] = labels[end]
+#     pop!(labels)
+#     g
+# end
+
+# """
+#     eliminate!(graph, labels, vertex)
+
+# Connects the neighbours of the given vertex into a clique before removing 
+# it from the graph.
+
+# The arrays of vertex labels and cliqueness are also updated to reflect the 
+# reording of vertex indices when the graph is updated.
+# """
+# function eliminate!(g::AbstractGraph, labels, c_map, v)
+#     Nᵥ = all_neighbors(g, v)::Array{Int64, 1}
+#     for i = 1:length(Nᵥ)-1
+#         vi = Nᵥ[i]
+#         for j = i+1:length(Nᵥ)
+#             vj = Nᵥ[j]
+
+#             # Try add an edge connecting vi and ui. If successful, update `c_map`.
+#             edge_added = add_edge!(g, vi, vj)
+#             if edge_added
+#                 # Common neighbours of vi and vj have one less edge to add
+#                 # when being eliminated after vi and ui are connected.
+#                 Nvi = all_neighbors(g, vi)::Array{Int64, 1}
+#                 Nvj = all_neighbors(g, vj)::Array{Int64, 1}
+#                 for n in Nvi
+#                     if n in Nvj
+#                         c_map[n] -= 1
+#                     end
+#                 end
+
+#                 # ui and vi are now neighbours so their cliqueness may increase.
+#                 for n in Nvi
+#                     if !(n == vj) && !(has_edge(g, n, vj)::Bool)
+#                         c_map[vi] += 1
+#                     end
+#                 end
+#                 for n in Nvj
+#                     if !(n == vi) && !(has_edge(g, n, vi)::Bool)
+#                         c_map[vj] += 1
+#                     end
+#                 end
+#             end
+#         end
+#     end
+
+#     # Removing v from G means it's also removed from its neighbour's neighbourhood, so their 
+#     # cliqueness may be reduced.
+#     for n in Nᵥ
+#         Nₙ = all_neighbors(g, n)::Array{Int64, 1}
+#         for u in Nₙ
+#             if !(u == v)
+#                 if !has_edge(g, v, u)
+#                     c_map[n] -= 1
+#                 end
+#             end
+#         end
+#     end
+
+#     rem_vertex!(g, v)
+#     c_map[v] = c_map[end]
+#     labels[v] = labels[end]
+#     g
+# end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,7 +59,7 @@ function find_treewidth_from_order(G::lg.AbstractGraph, order::Array{Int, 1})
     for v_label in order
         v = findfirst(vl -> vl == v_label, labels)
         τ = max(τ, lg.degree(G, v))
-        eliminate!(G, labels, v)
+        lg_eliminate!(G, labels, v)
     end
     τ
 end
@@ -125,7 +125,7 @@ it from the graph.
 The array of vertex labels are also updated to reflect the 
 reording of vertex indices when the graph is updated.
 """
-function eliminate!(g::lg.AbstractGraph, labels, v)
+function lg_eliminate!(g::lg.AbstractGraph, labels, v)
     Nᵥ = lg.all_neighbors(g, v)::Array{Int64, 1}
     for i = 1:length(Nᵥ)-1
         vi = Nᵥ[i]
@@ -148,7 +148,7 @@ it from the graph.
 The arrays of vertex labels and cliqueness are also updated to reflect the 
 reording of vertex indices when the graph is updated.
 """
-function eliminate!(g::lg.AbstractGraph, labels, c_map, v)
+function lg_eliminate!(g::lg.AbstractGraph, labels, c_map, v)
     Nᵥ = lg.all_neighbors(g, v)::Array{Int64, 1}
     for i = 1:length(Nᵥ)-1
         vi = Nᵥ[i]

--- a/test/branch_and_bound_tests.jl
+++ b/test/branch_and_bound_tests.jl
@@ -4,9 +4,9 @@
 
     # Test the main branch and bound algorithm.
     dfs_report = branch_and_bound_dfs(g, 2.0)
-    order = dfs_report.best_order
+    order = dfs_report.order
     @test length(order) == VertexEliminationOrders.lg.nv(g)
-    @test dfs_report.best_tw == find_treewidth_from_order(g, order)
+    @test dfs_report.tw == find_treewidth_from_order(g, order)
 
 
     

--- a/test/branch_and_bound_tests.jl
+++ b/test/branch_and_bound_tests.jl
@@ -3,26 +3,7 @@
     g = graph_from_gr("../examples/test.gr")
 
     # Test the main branch and bound algorithm.
-    dfs_report = branch_and_bound_dfs(g, 2.0)
-    order = dfs_report.order
+    tw, order, report = estimate_treewidth(g, 2.0)
     @test length(order) == VertexEliminationOrders.lg.nv(g)
-    @test dfs_report.tw == find_treewidth_from_order(g, order)
-
-
-    
-    # Create a DFSState to test removing and restoring simplicial vertices.
-    g = graph_from_gr("../examples/sycamore_53_20_0.gr")
-    state_i = VEO.DFSState(Graph(g), 
-                       VEO.UpperBound(0, Int[], Base.Threads.SpinLock()), 
-                       VEO.LowerBounds(), 0.0, 42)
-    state_f = deepcopy(state_i)
-
-    # # Remove and restore simplicial vertices.
-    # removed_vertices, curr_tw = VEO.remove_simplicial_vertices!(state_f, 0)
-    # VEO.restore_simplicial_vertices!(state_f, removed_vertices)
-
-    # # Check if the graph is returned to its original state.
-    # @test state_f.graph == state_i.graph
-    # @test state_f.labels == state_i.labels
-    # @test state_f.c_map == state_i.c_map
+    @test tw == find_treewidth_from_order(g, order)
 end

--- a/test/branch_and_bound_tests.jl
+++ b/test/branch_and_bound_tests.jl
@@ -5,24 +5,24 @@
     # Test the main branch and bound algorithm.
     dfs_report = branch_and_bound_dfs(g, 2.0)
     order = dfs_report.best_order
-    @test length(order) == nv(g)
+    @test length(order) == VertexEliminationOrders.lg.nv(g)
     @test dfs_report.best_tw == find_treewidth_from_order(g, order)
 
 
     
     # Create a DFSState to test removing and restoring simplicial vertices.
     g = graph_from_gr("../examples/sycamore_53_20_0.gr")
-    state_i = VEO.DFSState(deepcopy(g), 
+    state_i = VEO.DFSState(Graph(g), 
                        VEO.UpperBound(0, Int[], Base.Threads.SpinLock()), 
                        VEO.LowerBounds(), 0.0, 42)
     state_f = deepcopy(state_i)
 
-    # Remove and restore simplicial vertices.
-    removed_vertices, curr_tw = VEO.remove_simplicial_vertices!(state_f, 0)
-    VEO.restore_simplicial_vertices!(state_f, removed_vertices)
+    # # Remove and restore simplicial vertices.
+    # removed_vertices, curr_tw = VEO.remove_simplicial_vertices!(state_f, 0)
+    # VEO.restore_simplicial_vertices!(state_f, removed_vertices)
 
-    # Check if the graph is returned to its original state.
-    @test state_f.graph == state_i.graph
-    @test state_f.labels == state_i.labels
-    @test state_f.c_map == state_i.c_map
+    # # Check if the graph is returned to its original state.
+    # @test state_f.graph == state_i.graph
+    # @test state_f.labels == state_i.labels
+    # @test state_f.c_map == state_i.c_map
 end

--- a/test/heuristic_tests.jl
+++ b/test/heuristic_tests.jl
@@ -1,22 +1,22 @@
-@testset "Heuristic tests.jl" begin
+@testset "Heuristic tests" begin
     # Load a graph to test on.
     g = graph_from_gr("../examples/test.gr")
 
     # Test the min fill heuristic.
     order, tw = min_fill(g)
-    @test length(order) == nv(g)
+    @test length(order) == lg.nv(g)
 
     # Test min fill sampling
     order, tw = min_fill(g, 10)
-    @test length(order) == nv(g)
+    @test length(order) == lg.nv(g)
 
-    # Test the min width heuristic.
-    order, tw = min_width(g)
-    @test length(order) == nv(g)
+    # # Test the min width heuristic.
+    # order, tw = min_width(g)
+    # @test length(order) == lg.nv(g)
 
-    # Test sampling version of min width.
-    order, tw = min_width(g, 10)
-    @test length(order) == nv(g)
+    # # Test sampling version of min width.
+    # order, tw = min_width(g, 10)
+    # @test length(order) == lg.nv(g)
 
     # Test maximum minimum degree heuristic for a lower bound.
     lb = mmd(g)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,5 +13,5 @@ import VertexEliminationOrders as VEO
 end
 
 include("graph_tests.jl")
-include("heuristic_tests.jl")
+# include("heuristic_tests.jl")
 include("branch_and_bound_tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,5 +13,5 @@ import VertexEliminationOrders as VEO
 end
 
 include("graph_tests.jl")
-# include("heuristic_tests.jl")
+include("heuristic_tests.jl")
 include("branch_and_bound_tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,17 @@
 using VertexEliminationOrders
 using Test
 
+import LightGraphs as lg
+
 import VertexEliminationOrders as VEO
 
 @testset "VertexEliminationOrders.jl" begin
     # Test the graph io.
     g = graph_from_gr("../examples/test.gr")
-    @test nv(g) == 27
-    @test ne(g) == 36
+    @test lg.nv(g) == 27
+    @test lg.ne(g) == 36
 end
 
+include("graph_tests.jl")
 include("heuristic_tests.jl")
 include("branch_and_bound_tests.jl")


### PR DESCRIPTION
A new graph struct, with a memory of when vertices are eliminated and edges are added, was implemented to reduce the number of memory allocations during the depth first search.

A custom priority queue was also added to reduce the allocations and improve the performance of the mmd heuristic for a lower bound on the treewidth.

Apart from the initial set up of the calculation, the depth first search is now non-allocating. 